### PR TITLE
Modified setup. Package is called apclattice now.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,16 @@
 import setuptools
 
+# take the long description from the README
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="stochasticlattice-aormorningstar",
+    name="apclattice",
     version="0.0.0",
     author="Steven Li, Alan Morningstar, Pablo Oyler, and Holt Sakai",
-    author_email="aormorningstar@gmail.com",
-    description="A package for simulating stochastic dynamics of lattice systems.",
+    description="A package for simulating dynamics of lattice systems.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/holt-sakai/APC_Lattice",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
To install the package locally in "develop mode" run

```
python setup.py develop
```

And to uninstall locally run

```
python setup.py develop --uninstall
```

When installed in develop mode, you can import the package using

```
import apclattice
```